### PR TITLE
Bump GNU Unifont version to UnifontEX to improve compatibility (and add Plane 1)

### DIFF
--- a/firmware/drivers/lcd-scroll.c
+++ b/firmware/drivers/lcd-scroll.c
@@ -64,8 +64,8 @@ void LCDFN(scroll_stop_viewport_rect)(const struct viewport *vp, int x, int y, i
         struct scrollinfo *s = &LCDFN(scroll_info).scroll[i];
         /* check if the specified area crosses the viewport in some way */
         if (s->vp == vp
-            && (x < (s->x+s->width) && (x+width) >= s->x)
-            && (y < (s->y+s->height) && (y+height) >= s->y))
+            && (x < (s->x+s->width) && (x+width) > s->x)
+            && (y < (s->y+s->height) && (y+height) > s->y))
         {
             /* inform scroller about end of scrolling */
             s->line = NULL;

--- a/firmware/target/mips/ingenic_x1000/nand-x1000.c
+++ b/firmware/target/mips/ingenic_x1000/nand-x1000.c
@@ -94,6 +94,7 @@ static const struct nand_chip chip_gd5f1gq4xexx = {
 };
 
 #define chip_ds35x1gaxxx chip_gd5f1gq4xexx
+#define chip_gd5f1gq5xexxg chip_gd5f1gq4xexx
 
 const struct nand_chip_id supported_nand_chips[] = {
     NAND_CHIP_ID(&chip_ato25d1ga, NAND_READID_ADDR, 0x9b, 0x12),
@@ -102,6 +103,8 @@ const struct nand_chip_id supported_nand_chips[] = {
     NAND_CHIP_ID(&chip_gd5f1gq4xexx, NAND_READID_ADDR, 0xc8, 0xc1),
     NAND_CHIP_ID(&chip_ds35x1gaxxx, NAND_READID_ADDR, 0xe5, 0x71), /* 3.3 V */
     NAND_CHIP_ID(&chip_ds35x1gaxxx, NAND_READID_ADDR, 0xe5, 0x21), /* 1.8 V */
+    NAND_CHIP_ID(&chip_gd5f1gq5xexxg, NAND_READID_ADDR, 0xc8, 0x51), /* 3.3 V */
+    NAND_CHIP_ID(&chip_gd5f1gq5xexxg, NAND_READID_ADDR, 0xc8, 0x41), /* 1.8 V */
 };
 
 const size_t nr_supported_nand_chips = ARRAYLEN(supported_nand_chips);


### PR DESCRIPTION
The version of GNU Unifont in Rockbox is 15 years out of date. It doesn't even support Plane 1, even as MANY songs are using emoji in their titles. This has them. It also has MANY, MANY, MANY other special Unicode characters. Plane 0 goes to Unifont 15.0.06-JP (from June 4th, 2023, it's the last and most-complete TrueType version of Unifont), and Plane 1 goes Unifont 11.0.01 Upper from 2018, the highest version you can go. 11.0.02 Upper won't merge with 11.0.01 base or any higher version. All due to 65535 glyphs max in TrueType and BDF. Anyways, this is MUCH better than the 2008 version of Unifont used in Rockbox. With this, you can actually display songs from groups like FUNERALPARTY that have emoji/etc. in their names.  

UnifontEX's page can be found [here](http://stgiga.github.io/UnifontEX/) and it has quite a few other formats available besides BDF. From the original TrueType, to BDF, to OTB, DFONT, various webfont formats, and more.